### PR TITLE
Drop THIS_MODULE from class_create

### DIFF
--- a/linux-gpib-kernel/drivers/gpib/sys/osinit.c
+++ b/linux-gpib-kernel/drivers/gpib/sys/osinit.c
@@ -207,7 +207,7 @@ static int __init gpib_common_init_module( void )
 		printk( "gpib: can't get major %d\n", GPIB_CODE );
 		return -EIO;
 	}
-	gpib_class = class_create(THIS_MODULE, "gpib_common");
+	gpib_class = class_create("gpib_common");
 	if(IS_ERR(gpib_class))
 	{
 		printk("gpib: failed to create gpib class\n");


### PR DESCRIPTION
As-is, this FTBFS on 6.8.12-amd64. There must have been a change recently, I checked for similar class_create callsites and this seemed to have worked for me. I'm not tracking these changes well enough to know if this is a good idea or not, but figured i'd offer the patch up.